### PR TITLE
Add and use Docker image for vehicle manufacture tutorial

### DIFF
--- a/.bluemix/pipeline.sh
+++ b/.bluemix/pipeline.sh
@@ -384,7 +384,7 @@ EOF
 
   date
   printf "\n --- Creating the Vehicle manufacture application '${CF_APP}' ---\n"
-  cf push ${CF_APP} --no-start -c "node server/app.js"
+  cf push ${CF_APP} --docker-image sstone1/vehicle-manufacture-tutorial -i 1 -m 128M --no-start --no-manifest
   cf set-env ${CF_APP} REST_SERVER_CONFIG "{\"webSocketURL\": \"wss://${REST_SERVER_URL}\", \"httpURL\": \"https://${REST_SERVER_URL}/api\"}"
 
   # Bind app to the blockchain service

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:8-alpine
+ENV NPM_CONFIG_LOGLEVEL warn
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY package.json bower.json .bowerrc /usr/src/app/
+RUN apk add --no-cache git && \
+    npm install --production -g bower pm2 && \
+    npm install --production  && \
+    bower install && \
+    bower cache clean && \
+    npm uninstall -g bower && \
+    npm cache clean --force && \
+    apk del git
+COPY . /usr/src/app/
+EXPOSE 6001
+CMD [ "pm2-docker", "npm", "--", "start" ]

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,0 @@
----
-applications:
-- disk_quota: 1024M
-  name: vehicleManufacturing
-  command: "node server/app.js"
-  path: "."
-  instances: 1
-  memory: 256M


### PR DESCRIPTION
Signed-off-by: Simon Stone <sstone1@uk.ibm.com>

- Add `Dockerfile` for building vehicle manufacture tutorial into a Docker image.
- Use vehicle manufacture tutorial Docker image instead of slow Cloud Foundry application.
- Delete pointless `manifest.yml` file.