### PR TITLE
Remove status from header

### DIFF
--- a/client/app/directives/header/header.html
+++ b/client/app/directives/header/header.html
@@ -1,5 +1,5 @@
 <div id="header" >
-    <div><b class="addSpace">IBM Blockchain Platform:</b> Develop - {{ appName }} ({{ mode }}) - Sample Application</div>
+    <div><b class="addSpace">IBM Blockchain Platform:</b> Develop - {{ appName }} - Sample Application</div>
     <div>
         <b>{{ identity.name }}</b>, {{ identity.type }}
         <div class="pipe" ></div> 


### PR DESCRIPTION
Removing the tutorial status from the header which shouldn't appear. 

![screen shot 2018-03-19 at 11 50 26](https://user-images.githubusercontent.com/31732124/37593955-bdf8102c-2b6b-11e8-8a2e-b9ceedda6d8e.png)
