### PR TITLE
Downgraded grpc to 1.9.1 - added lines 265 and 266

### DIFF
--- a/.bluemix/pipeline.sh
+++ b/.bluemix/pipeline.sh
@@ -262,7 +262,8 @@ printf "\n --- Got service credentials ---\n"
   printf "\n ---- Install composer-cli and composer-wallet-cloudant ----- \n "
 
   npm install -g composer-cli@0.18.1 @ampretia/composer-wallet-cloudant
-
+  npm --prefix /home/pipeline/.nvm/versions/node/v8.11.1/lib/node_modules/composer-cli/ uninstall grpc 
+  npm --prefix /home/pipeline/.nvm/versions/node/v8.11.1/lib/node_modules/composer-cli/ install grpc@1.9.1
   composer -v
 
   date


### PR DESCRIPTION
As per error at https://stackoverflow.com/questions/50134379/error-invoking-chaincode-using-node-js-sdk-typeerror-cannot-read-property-get