### PR TITLE
Added dist dir

### DIFF
--- a/contracts/dist/.gitignore
+++ b/contracts/dist/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Hello,

Doing the tutorial the Step 3 fails due to the inexistence of the "dist" folder when clonning the repository. It is easy to fix but many beginners may be clueless of what is causing the error. Therefore I am submitting this pull request. Thank you

Regards,
Marcos.